### PR TITLE
Bump pako from 1.0.11 to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "conversion"
   ],
   "dependencies": {
-    "pako": "^1.0.10"
+    "pako": "^2.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,10 +1069,10 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-pako@^1.0.10:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+pako@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.3.tgz#cdf475e31b678565251406de9e759196a0ea7a43"
+  integrity sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==
 
 pascalcase@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Hi,
referring to [#863](https://github.com/Hopding/pdf-lib/pull/863) pull request, and taking into account that types for pako did not change you can bump dependency. I have tested that lib still builds.