### PR TITLE
Update UPNG.js from upstream, document tabs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ var pngImage = window.UPNG.decode(/* ... */)
 
 UPNG.js supports APNG and the interface expects "frames". Regular PNG is just a single-frame animation (single-item array).
 
-#### `UPNG.encode(imgs, w, h, cnum, [dels])`
+#### `UPNG.encode(imgs, w, h, cnum, [dels], [tabs])`
 * `imgs`: array of frames. A frame is an ArrayBuffer containing the pixel data (RGBA, 8 bits per channel)
 * `w`, `h` : width and height of the image
 * `cnum`: number of colors in the result;  0: all colors (lossless PNG)
 * `dels`: array of millisecond delays for each frame (only when 2 or more frames)
+* `tabs`: object of options. `{ loop: 1 }` will play the animation only once (default is `0`, will play indefinitely).
 * returns an ArrayBuffer with binary data of a PNG file
 
 UPNG.js can do a lossy minification of PNG files, similar to [TinyPNG](https://tinypng.com/) and other tools. It performed quantization with [k-means algorithm](https://en.wikipedia.org/wiki/K-means_clustering) in the past, but now we use [K-d trees](https://en.wikipedia.org/wiki/K-d_tree).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ A small, fast and advanced PNG / APNG encoder and decoder. It is the main PNG en
 * [UPNG.Photopea.com](http://upng.photopea.com) - a separate minifier app, that uses UPNG.js
 * Support us by [making a donation](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=ivan%40kuckir%2ecom&lc=CZ&item_name=UPNG%2ejs&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted).
 
-Download and include the `UPNG.js` file in your code, or get it from NPM:
-
-```sh
-npm install upng-js
-```
+Download and include the `UPNG.js` file in your code.
 
 ## Encoder
 

--- a/UPNG.js
+++ b/UPNG.js
@@ -413,6 +413,8 @@ UPNG._copyTile = function(sb, sw, sh, tb, tw, th, xoff, yoff, mode)
 
 
 
+
+
 UPNG.encode = function(bufs, w, h, ps, dels, tabs, forbidPlte)
 {
 	if(ps==null) ps=0;

--- a/UPNG.js
+++ b/UPNG.js
@@ -113,6 +113,7 @@ UPNG.decode = function(buff)
 		//console.log(type,len);
 		
 		if     (type=="IHDR")  {  UPNG.decode._IHDR(data, offset, out);  }
+		else if(type=="CgBI")  {  out.tabs[type] = data.slice(offset,offset+4);  }
 		else if(type=="IDAT") {
 			for(var i=0; i<len; i++) dd[doff+i] = data[offset+i];
 			doff += len;
@@ -159,7 +160,12 @@ UPNG.decode = function(buff)
 			var ltag = bin.readASCII(data, off, nz-off);  off = nz + 1;
 			nz = bin.nextZero(data, off);
 			var tkeyw = bin.readUTF8(data, off, nz-off);  off = nz + 1;
-			var text  = bin.readUTF8(data, off, len-(off-offset));
+			var text, tl=len-(off-offset);
+			if(cflag==0) text  = bin.readUTF8(data, off, tl);
+			else {
+				var bfr = UPNG.decode._inflate(data.slice(off,off+tl));
+				text = bin.readUTF8(bfr,0,bfr.length);
+			}
 			out.tabs[type][keyw] = text;
 		}
 		else if(type=="PLTE") {
@@ -202,7 +208,8 @@ UPNG.decode = function(buff)
 UPNG.decode._decompress = function(out, dd, w, h) {
 	var time = Date.now();
 	var bpp = UPNG.decode._getBPP(out), bpl = Math.ceil(w*bpp/8), buff = new Uint8Array((bpl+1+out.interlace)*h);
-	dd = UPNG.decode._inflate(dd,buff);
+	if(out.tabs["CgBI"]) dd = UPNG.inflateRaw(dd,buff);
+	else                 dd = UPNG.decode._inflate(dd,buff);
 	//console.log(dd.length, buff.length);
 	//console.log(Date.now()-time);
 
@@ -590,7 +597,7 @@ UPNG.encode.compress = function(bufs, w, h, ps, prms) // prms:  onlyBlend, minBi
 	if(ps!=0) {
 		var nbufs = [];  for(var i=0; i<frms.length; i++) nbufs.push(frms[i].img.buffer);
 		
-		var abuf = UPNG.encode.concatRGBA(nbufs), qres = UPNG.quantize(abuf, ps);
+		var abuf = UPNG.encode.concatRGBA(nbufs), qres = UPNG.quantize(abuf, ps);  console.log(qres);
 		var cof = 0, bb = new Uint8Array(qres.abuf);
 		for(var i=0; i<frms.length; i++) {  var ti=frms[i].img, bln=ti.length;  inds.push(new Uint8Array(qres.inds.buffer, cof>>2, bln>>2));
 			for(var j=0; j<bln; j+=4) {  ti[j]=bb[cof+j];  ti[j+1]=bb[cof+j+1];  ti[j+2]=bb[cof+j+2];  ti[j+3]=bb[cof+j+3];  }    cof+=bln;  }
@@ -787,8 +794,10 @@ UPNG.encode._filterZero = function(img,h,bpp,bpl,data, filter, levelZero)
 	else if(h*bpl>500000 || bpp==1) ftry=[0];
 	var opts;  if(levelZero) opts={level:0};
 	
-	var CMPR = (levelZero && UZIP!=null) ? UZIP : pako;
 	
+	var CMPR = (data.length>10e6 && UZIP!=null) ? UZIP : pako;
+	
+	var time = Date.now();
 	for(var i=0; i<ftry.length; i++) {
 		for(var y=0; y<h; y++) UPNG.encode._filterLine(data, img, y, bpl, bpp, ftry[i]);
 		//var nimg = new Uint8Array(data.length);
@@ -798,6 +807,7 @@ UPNG.encode._filterZero = function(img,h,bpp,bpl,data, filter, levelZero)
 		//console.log(crc, UZIP.adler(data,2,data.length-6));
 		fls.push(CMPR["deflate"](data,opts));
 	}
+	
 	var ti, tsize=1e9;
 	for(var i=0; i<fls.length; i++) if(fls[i].length<tsize) {  ti=i;  tsize=fls[i].length;  }
 	return fls[ti];
@@ -860,18 +870,21 @@ UPNG.quantize = function(abuf, ps)
 	var planeDst = UPNG.quantize.planeDst;
 	var sb = oimg, tb = nimg32, len=sb.length;
 		
-	var inds = new Uint8Array(oimg.length>>2);
-	for(var i=0; i<len; i+=4) {
-		var r=sb[i]*(1/255), g=sb[i+1]*(1/255), b=sb[i+2]*(1/255), a=sb[i+3]*(1/255);
-		
-		//  exact, but too slow :(
-		var nd = UPNG.quantize.getNearest(root, r, g, b, a);
-		//var nd = root;
-		//while(nd.left) nd = (planeDst(nd.est,r,g,b,a)<=0) ? nd.left : nd.right;
-		
-		inds[i>>2] = nd.ind;
-		tb[i>>2] = nd.est.rgba;
-	}
+	var inds = new Uint8Array(oimg.length>>2), nd;
+	if(oimg.length<20e6)  // precise, but slow :(
+		for(var i=0; i<len; i+=4) {
+			var r=sb[i]*(1/255), g=sb[i+1]*(1/255), b=sb[i+2]*(1/255), a=sb[i+3]*(1/255);
+			
+			nd = UPNG.quantize.getNearest(root, r, g, b, a);
+			inds[i>>2] = nd.ind;  tb[i>>2] = nd.est.rgba;
+		}
+	else 
+		for(var i=0; i<len; i+=4) {
+			var r=sb[i]*(1/255), g=sb[i+1]*(1/255), b=sb[i+2]*(1/255), a=sb[i+3]*(1/255);
+			
+			nd = root;  while(nd.left) nd = (planeDst(nd.est,r,g,b,a)<=0) ? nd.left : nd.right;
+			inds[i>>2] = nd.ind;  tb[i>>2] = nd.est.rgba;
+		}
 	return {  abuf:nimg.buffer, inds:inds, plte:leafs  };
 }
 

--- a/UPNG.js
+++ b/UPNG.js
@@ -998,7 +998,7 @@ UPNG.quantize.estats = function(stats){
 	];
 	
 	var A = Rj, M = UPNG.M4;
-	var b = [0.5,0.5,0.5,0.5], mi = 0, tmi = 0;
+	var b = [Math.random(),Math.random(),Math.random(),Math.random()], mi = 0, tmi = 0;
 	
 	if(N!=0)
 	for(var i=0; i<16; i++) {

--- a/UPNG.js
+++ b/UPNG.js
@@ -414,7 +414,6 @@ UPNG._copyTile = function(sb, sw, sh, tb, tw, th, xoff, yoff, mode)
 
 
 
-
 UPNG.encode = function(bufs, w, h, ps, dels, tabs, forbidPlte)
 {
 	if(ps==null) ps=0;
@@ -586,12 +585,12 @@ UPNG.encode.compress = function(bufs, w, h, ps, prms) // prms:  onlyBlend, minBi
 	var frms = UPNG.encode.framize(bufs, w, h, onlyBlend, evenCrd, forbidPrev);
 	//console.log("framize", Date.now()-time);  time = Date.now();
 	
-	var cmap={}, plte=[], inds=[];  
+	var cmap={}, plte=[], inds=[]; 
 	
 	if(ps!=0) {
 		var nbufs = [];  for(var i=0; i<frms.length; i++) nbufs.push(frms[i].img.buffer);
 		
-		var abuf = UPNG.encode.concatRGBA(nbufs), qres = UPNG.quantize(abuf, ps);  
+		var abuf = UPNG.encode.concatRGBA(nbufs), qres = UPNG.quantize(abuf, ps);
 		var cof = 0, bb = new Uint8Array(qres.abuf);
 		for(var i=0; i<frms.length; i++) {  var ti=frms[i].img, bln=ti.length;  inds.push(new Uint8Array(qres.inds.buffer, cof>>2, bln>>2));
 			for(var j=0; j<bln; j+=4) {  ti[j]=bb[cof+j];  ti[j+1]=bb[cof+j+1];  ti[j+2]=bb[cof+j+2];  ti[j+3]=bb[cof+j+3];  }    cof+=bln;  }
@@ -985,9 +984,9 @@ UPNG.quantize.estats = function(stats){
 	var b = [0.5,0.5,0.5,0.5], mi = 0, tmi = 0;
 	
 	if(N!=0)
-	for(var i=0; i<10; i++) {
+	for(var i=0; i<16; i++) {
 		b = M.multVec(A, b);  tmi = Math.sqrt(M.dot(b,b));  b = M.sml(1/tmi,  b);
-		if(Math.abs(tmi-mi)<1e-9) break;  mi = tmi;
+		if(i!=0 && Math.abs(tmi-mi)<1e-9) break;  mi = tmi;
 	}	
 	//b = [0,0,1,0];  mi=N;
 	var q = [m0*iN, m1*iN, m2*iN, m3*iN];

--- a/UPNG.js
+++ b/UPNG.js
@@ -143,11 +143,16 @@ UPNG.decode = function(buff)
 			out.tabs[type] = [];
 			for(var i=0; i<8; i++) out.tabs[type].push(bin.readUint(data, offset+i*4));
 		}
-		else if(type=="tEXt") {
+		else if(type=="tEXt" || type=="zTXt") {
 			if(out.tabs[type]==null) out.tabs[type] = {};
 			var nz = bin.nextZero(data, offset);
 			var keyw = bin.readASCII(data, offset, nz-offset);
-			var text = bin.readASCII(data, nz+1, offset+len-nz-1);
+			var text, tl=offset+len-nz-1;
+			if(type=="tEXt") text = bin.readASCII(data, nz+1, tl);
+			else {
+				var bfr = UPNG.decode._inflate(data.slice(nz+2,nz+2+tl));
+				text = bin.readUTF8(bfr,0,bfr.length);
+			}
 			out.tabs[type][keyw] = text;
 		}
 		else if(type=="iTXt") {
@@ -416,7 +421,6 @@ UPNG._copyTile = function(sb, sw, sh, tb, tw, th, xoff, yoff, mode)
 		}
 	return true;
 }
-
 
 
 

--- a/UPNG.js
+++ b/UPNG.js
@@ -228,7 +228,7 @@ UPNG.decode._decompress = function(out, dd, w, h) {
 UPNG.decode._inflate = function(data, buff) {  var out=UPNG["inflateRaw"](new Uint8Array(data.buffer, 2,data.length-6),buff);  return out;  }
 UPNG.inflateRaw=function(){var H={};H.H={};H.H.N=function(N,W){var R=Uint8Array,i=0,m=0,J=0,h=0,Q=0,X=0,u=0,w=0,d=0,v,C;
 if(N[0]==3&&N[1]==0)return W?W:new R(0);var V=H.H,n=V.b,A=V.e,l=V.R,M=V.n,I=V.A,e=V.Z,b=V.m,Z=W==null;
-if(Z)W=new R(N.length>>>2<<4);while(i==0){i=n(N,d,1);m=n(N,d+1,2);d+=3;if(m==0){if((d&7)!=0)d+=8-(d&7);
+if(Z)W=new R(N.length>>>2<<5);while(i==0){i=n(N,d,1);m=n(N,d+1,2);d+=3;if(m==0){if((d&7)!=0)d+=8-(d&7);
 var D=(d>>>3)+4,q=N[D-4]|N[D-3]<<8;if(Z)W=H.H.W(W,w+q);W.set(new R(N.buffer,N.byteOffset+D,q),w);d=D+q<<3;
 w+=q;continue}if(Z)W=H.H.W(W,w+(1<<17));if(m==1){v=b.J;C=b.h;X=(1<<9)-1;u=(1<<5)-1}if(m==2){J=A(N,d,5)+257;
 h=A(N,d+5,5)+1;Q=A(N,d+10,4)+4;d+=14;var E=d,j=1;for(var c=0;c<38;c+=2){b.Q[c]=0;b.Q[c+1]=0}for(var c=0;

--- a/UPNG.js
+++ b/UPNG.js
@@ -228,7 +228,7 @@ UPNG.decode._decompress = function(out, dd, w, h) {
 UPNG.decode._inflate = function(data, buff) {  var out=UPNG["inflateRaw"](new Uint8Array(data.buffer, 2,data.length-6),buff);  return out;  }
 UPNG.inflateRaw=function(){var H={};H.H={};H.H.N=function(N,W){var R=Uint8Array,i=0,m=0,J=0,h=0,Q=0,X=0,u=0,w=0,d=0,v,C;
 if(N[0]==3&&N[1]==0)return W?W:new R(0);var V=H.H,n=V.b,A=V.e,l=V.R,M=V.n,I=V.A,e=V.Z,b=V.m,Z=W==null;
-if(Z)W=new R(N.length>>>2<<3);while(i==0){i=n(N,d,1);m=n(N,d+1,2);d+=3;if(m==0){if((d&7)!=0)d+=8-(d&7);
+if(Z)W=new R(N.length>>>2<<4);while(i==0){i=n(N,d,1);m=n(N,d+1,2);d+=3;if(m==0){if((d&7)!=0)d+=8-(d&7);
 var D=(d>>>3)+4,q=N[D-4]|N[D-3]<<8;if(Z)W=H.H.W(W,w+q);W.set(new R(N.buffer,N.byteOffset+D,q),w);d=D+q<<3;
 w+=q;continue}if(Z)W=H.H.W(W,w+(1<<17));if(m==1){v=b.J;C=b.h;X=(1<<9)-1;u=(1<<5)-1}if(m==2){J=A(N,d,5)+257;
 h=A(N,d+5,5)+1;Q=A(N,d+10,4)+4;d+=14;var E=d,j=1;for(var c=0;c<38;c+=2){b.Q[c]=0;b.Q[c+1]=0}for(var c=0;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "upng-js",
   "description": "Small, fast and advanced PNG / APNG encoder and decoder",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "homepage": "https://github.com/photopea/UPNG.js",
   "author": "photopea (https://github.com/photopea)",
   "contributors": [


### PR DESCRIPTION
I updated the UPNG.js from https://github.com/photopea/UPNG.js and documented (a small part of) the `tabs` option.
`tabs` can do a ton more, but I was struggling to find out how I can limit the number of animations so I only documented that.

Is this something you would consider merging or should I try to make a pr upstream?